### PR TITLE
feat: sector-optimized strategy signals with scan-to-signals pipeline

### DIFF
--- a/tests/unit/test_sector_params.py
+++ b/tests/unit/test_sector_params.py
@@ -1,0 +1,145 @@
+"""Tests for sector-aware strategy parameter loading."""
+import json
+import pytest
+from pathlib import Path
+from trader.strategies.factory import (
+    get_strategy, get_sector_params, _load_sector_params, _SECTOR_PARAMS_FILE,
+)
+from trader.strategies.rsi import RSIStrategy
+from trader.strategies.macd import MACDStrategy
+from trader.models.scan import ScanResult
+from trader.models.quote import Quote
+
+
+# ── Model tests ──────────────────────────────────────────────────────────────
+
+def test_scan_result_has_sector_fields():
+    r = ScanResult(symbol="NVDA", sector="Technology", industry="Semiconductors")
+    assert r.sector == "Technology"
+    assert r.industry == "Semiconductors"
+
+def test_scan_result_sector_defaults_empty():
+    r = ScanResult(symbol="AAPL")
+    assert r.sector == ""
+    assert r.industry == ""
+
+def test_quote_has_sector_fields():
+    q = Quote(ticker="NVDA", sector="Technology", industry="Semiconductors")
+    assert q.sector == "Technology"
+    assert q.industry == "Semiconductors"
+
+def test_quote_sector_defaults_empty():
+    q = Quote(ticker="AAPL")
+    assert q.sector == ""
+    assert q.industry == ""
+
+
+# ── Sector params file ──────────────────────────────────────────────────────
+
+def test_sector_params_file_exists():
+    assert _SECTOR_PARAMS_FILE.exists(), "sector_params.json should exist"
+
+def test_sector_params_file_valid_json():
+    data = json.loads(_SECTOR_PARAMS_FILE.read_text())
+    assert isinstance(data, dict)
+    # Should have at least Technology and Energy
+    assert "Technology" in data
+    assert "Energy" in data
+
+def test_sector_params_has_strategy_entries():
+    data = json.loads(_SECTOR_PARAMS_FILE.read_text())
+    tech = data["Technology"]
+    assert "rsi" in tech
+    assert "macd" in tech
+    assert "oversold" in tech["rsi"]
+
+
+# ── Factory: get_sector_params ───────────────────────────────────────────────
+
+def test_get_sector_params_returns_overrides():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None  # force reload
+    params = get_sector_params("Technology", "rsi")
+    assert params is not None
+    assert "oversold" in params
+
+def test_get_sector_params_case_insensitive():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    p1 = get_sector_params("technology", "rsi")
+    p2 = get_sector_params("TECHNOLOGY", "rsi")
+    assert p1 == p2
+
+def test_get_sector_params_unknown_sector():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    assert get_sector_params("NonExistentSector", "rsi") is None
+
+def test_get_sector_params_unknown_strategy():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    assert get_sector_params("Technology", "unknown_strat") is None
+
+
+# ── Factory: get_strategy with sector ────────────────────────────────────────
+
+def test_get_strategy_with_sector_uses_overrides():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    strat = get_strategy("rsi", sector="Technology")
+    assert isinstance(strat, RSIStrategy)
+    # Technology RSI should use oversold=25 (not default 30)
+    assert strat.params["oversold"] == 25
+
+def test_get_strategy_without_sector_uses_defaults():
+    strat = get_strategy("rsi")
+    assert isinstance(strat, RSIStrategy)
+    assert strat.params["oversold"] == 30  # default
+
+def test_get_strategy_explicit_params_override_sector():
+    """Explicit params should always win over sector defaults."""
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    strat = get_strategy("rsi", params={"period": 7, "oversold": 20, "overbought": 80}, sector="Technology")
+    assert strat.params["oversold"] == 20  # explicit wins
+    assert strat.params["period"] == 7
+
+def test_get_strategy_energy_rsi_params():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    strat = get_strategy("rsi", sector="Energy")
+    # Energy RSI uses period=21 (longer for trend-following)
+    assert strat.params["period"] == 21
+
+def test_get_strategy_utilities_tighter_bands():
+    import trader.strategies.factory as mod
+    mod._sector_cache = None
+    strat = get_strategy("rsi", sector="Utilities")
+    # Utilities uses tighter bands: oversold=35, overbought=65
+    assert strat.params["oversold"] == 35
+    assert strat.params["overbought"] == 65
+
+
+# ── Sector params write-back (optimize --sector) ────────────────────────────
+
+def test_sector_params_write_back(tmp_path, monkeypatch):
+    """Simulates what optimize --sector does: writes best params back to file."""
+    import trader.strategies.factory as mod
+
+    # Create a temp sector_params.json
+    sp = tmp_path / "sector_params.json"
+    sp.write_text(json.dumps({"Technology": {"rsi": {"period": 14, "oversold": 30, "overbought": 70}}}))
+
+    monkeypatch.setattr(mod, "_SECTOR_PARAMS_FILE", sp)
+    monkeypatch.setattr(mod, "_sector_cache", None)
+
+    # Simulate optimize writing back
+    raw = json.loads(sp.read_text())
+    raw["Technology"]["rsi"] = {"period": 21, "oversold": 25, "overbought": 75}
+    sp.write_text(json.dumps(raw, indent=2))
+    mod._sector_cache = None
+
+    # Verify the updated params are loaded
+    params = get_sector_params("Technology", "rsi")
+    assert params["period"] == 21
+    assert params["oversold"] == 25

--- a/trader/adapters/base.py
+++ b/trader/adapters/base.py
@@ -54,6 +54,10 @@ class Adapter(ABC):
     @abstractmethod
     async def delete_alert(self, alert_id: str) -> bool: ...
 
+    async def get_contract_details(self, conid: int) -> dict:
+        """Return sector/industry metadata for a contract. Override in subclass."""
+        return {}
+
     @abstractmethod
     async def scan(
         self,

--- a/trader/adapters/ibkr_rest/adapter.py
+++ b/trader/adapters/ibkr_rest/adapter.py
@@ -376,6 +376,19 @@ class IBKRRestAdapter(Adapter):
         )
         return bool(resp.get("success") or resp.get("deleted") or True)
 
+    # ----------------------------------------------------------- contract info
+
+    async def get_contract_details(self, conid: int) -> dict:
+        """Fetch sector/industry from IBKR contract info endpoint."""
+        try:
+            data = await self._client.get(f"/iserver/contract/{conid}/info")
+            return {
+                "sector": data.get("category", "") or data.get("sector", ""),
+                "industry": data.get("industry", ""),
+            }
+        except Exception:
+            return {"sector": "", "industry": ""}
+
     # ------------------------------------------------------------------ scanner
 
     async def scan(
@@ -393,17 +406,24 @@ class IBKRRestAdapter(Adapter):
         }
         data = await self._client.post("/iserver/scanner/run", json=payload)
         contracts = data.get("contracts", []) if isinstance(data, dict) else data
-        return [
-            ScanResult(
+        trimmed = contracts[:limit]
+
+        # Enrich with sector/industry from contract details (parallel)
+        async def _enrich(c: dict) -> ScanResult:
+            cid = c.get("con_id")
+            details = await self.get_contract_details(cid) if cid else {}
+            return ScanResult(
                 symbol=c.get("symbol", ""),
                 company_name=c.get("company_name", ""),
-                conid=c.get("con_id") or None,
+                conid=cid or None,
                 listing_exchange=c.get("listing_exchange", ""),
                 sec_type=c.get("sec_type", ""),
                 column_value=c.get("column_name", ""),
+                sector=details.get("sector", ""),
+                industry=details.get("industry", ""),
             )
-            for c in contracts[:limit]
-        ]
+
+        return await asyncio.gather(*[_enrich(c) for c in trimmed])
 
     async def scan_params(self) -> dict:
         return await self._client.get("/iserver/scanner/params")

--- a/trader/cli/scan.py
+++ b/trader/cli/scan.py
@@ -146,12 +146,19 @@ def _run(ctx, coro):
               help="Maximum market cap in millions.")
 @click.option("--has-options", is_flag=True, default=False,
               help="Only include contracts with listed options.")
+# ── Signal overlay ─────────────────────────────────────────────────────────
+@click.option("--signals", is_flag=True, default=False,
+              help="Run strategy signals on each scan result (uses sector-optimized params).")
+@click.option("--strategy", default="rsi",
+              help="Strategy to run when --signals is set (rsi, macd, ma_cross, bnf, momentum).")
+@click.option("--lookback", default="90d",
+              help="History window for signals (e.g. 30d, 90d, 1y).")
 @click.pass_context
 def run_scan(ctx, scan_type, market, limit, price_above, price_below,
              volume_above, avg_volume_above, avg_usd_volume_above,
              ema20_above, ema50_above, ema200_above, ema200_below,
              change_above, change_below, mktcap_above, mktcap_below,
-             has_options):
+             has_options, signals, strategy, lookback):
     """
     Run a market scan by TYPE and return matching tickers.
 
@@ -170,9 +177,8 @@ def run_scan(ctx, scan_type, market, limit, price_above, price_below,
       trader scan run TOP_PERC_GAIN
       trader scan run MOST_ACTIVE --market STK.US.MAJOR --volume-above 500000 --price-above 5
       trader scan run HIGH_VS_52W_HL --ema200-above --avg-volume-above 200000 --limit 30
-      trader scan run OPT_VOLUME_MOST_ACTIVE --market STK.US.MAJOR
-      trader scan run TOP_PERC_GAIN --market STK.EU.LSE
-      trader scan run MOST_ACTIVE --market ETF.EQ.US.MAJOR
+      trader scan run TOP_PERC_GAIN --signals --strategy rsi
+      trader scan run HIGH_VS_52W_HL --signals --strategy macd --lookback 180d
     """
     filters = []
 
@@ -200,7 +206,64 @@ def run_scan(ctx, scan_type, market, limit, price_above, price_below,
     if has_options:
         filters.append({"code": "hasOptionsIs", "value": 1})
 
-    _run(ctx, lambda a: a.scan(scan_type, market, filters or None, limit))
+    if not signals:
+        _run(ctx, lambda a: a.scan(scan_type, market, filters or None, limit))
+        return
+
+    # Scan-to-signals pipeline: scan → enrich with sector → run strategy signals
+    adapter = get_adapter(ctx.obj["broker"], ctx.obj["config"])
+
+    async def run_with_signals():
+        await adapter.connect()
+        try:
+            results = await adapter.scan(scan_type, market, filters or None, limit)
+            return results
+        finally:
+            await adapter.disconnect()
+
+    try:
+        results = asyncio.run(run_with_signals())
+    except Exception as e:
+        click.echo(json.dumps({"error": str(e), "code": type(e).__name__}))
+        sys.exit(1)
+
+    # Run strategy signals on each scan result
+    from trader.strategies.factory import get_strategy
+    from trader.strategies.risk_filter import RiskFilter
+    from trader.strategies.stop_loss import atr as compute_atr, stop_level as compute_stop
+    from trader.cli.strategies import _fetch_ohlcv
+
+    rf = RiskFilter()
+    output = []
+    for r in results:
+        entry = r.model_dump()
+        try:
+            df = _fetch_ohlcv(r.symbol, "1d", lookback)
+            strat = get_strategy(strategy, sector=r.sector or None)
+            sig_series = strat.signals(df)
+            raw_signal = int(sig_series.iloc[-1])
+            try:
+                current_atr = round(float(compute_atr(df).iloc[-1]), 4)
+                price = float(df["close"].iloc[-1])
+                sl = round(compute_stop(df, entry_price=price), 4)
+            except Exception:
+                current_atr = None
+                sl = None
+            filtered = rf.filter(signal=raw_signal, quote=None,
+                                 position=None, sentiment=None)
+            entry["signal"] = filtered["signal"]
+            entry["signal_label"] = {1: "buy", -1: "sell", 0: "hold"}[filtered["signal"]]
+            entry["strategy"] = strategy
+            entry["strategy_params"] = strat.params
+            entry["filtered"] = filtered["filtered"]
+            entry["filter_reason"] = filtered["filter_reason"]
+            entry["atr"] = current_atr
+            entry["stop_level"] = sl
+        except Exception as e:
+            entry["signal"] = None
+            entry["signal_error"] = str(e)
+        output.append(entry)
+    output_json(output)
 
 
 @scan.command("types")

--- a/trader/cli/strategies.py
+++ b/trader/cli/strategies.py
@@ -74,19 +74,26 @@ def run_strategy(ctx, ticker, strategy, interval, lookback, params):
               help="Apply Benzinga sentiment as signal filter. Requires BENZINGA_API_KEY.")
 @click.option("--params", default=None,
               help='JSON strategy params e.g. \'{"period":14}\'')
+@click.option("--sector", default=None,
+              help="Sector name for sector-optimized params (e.g. Technology, Energy).")
 @click.pass_context
-def signals(ctx, tickers, strategy, interval, lookback, with_news, params):
+def signals(ctx, tickers, strategy, interval, lookback, with_news, params, sector):
     """
     Generate trading signals for one or more tickers.
 
     Returns signal 1 (buy), -1 (sell), 0 (hold) per ticker.
     Includes risk filter metadata (filtered, filter_reason).
 
-    Example: trader strategies signals --tickers AAPL,MSFT --strategy rsi --with-news
+    Pass --sector to use sector-optimized strategy parameters.
+
+    \b
+    Example:
+      trader strategies signals --tickers AAPL,MSFT --strategy rsi --with-news
+      trader strategies signals --tickers XOM,CVX --strategy rsi --sector Energy
     """
     ticker_list = [t.strip() for t in tickers.replace(",", " ").split()]
     p = json.loads(params) if params else None
-    strat = get_strategy(strategy, p)
+    strat = get_strategy(strategy, p, sector=sector)
     rf = RiskFilter()
     results = []
 
@@ -183,12 +190,19 @@ def backtest(ctx, ticker, strategy, from_date, params):
 @click.option("--metric", default="sharpe",
               type=click.Choice(["sharpe", "returns", "win_rate"]),
               help="Optimization metric: sharpe (default), returns, win_rate.")
+@click.option("--sector", default=None,
+              help="Sector name — if set, writes best params back to sector_params.json.")
 @click.pass_context
-def optimize(ctx, ticker, strategy, metric):
+def optimize(ctx, ticker, strategy, metric, sector):
     """
     Grid-search best parameters for STRATEGY on TICKER.
 
-    Example: trader strategies optimize AAPL --strategy rsi --metric sharpe
+    With --sector, writes optimized params back to sector_params.json for future use.
+
+    \b
+    Examples:
+      trader strategies optimize AAPL --strategy rsi --metric sharpe
+      trader strategies optimize XOM --strategy rsi --sector Energy
     """
     _grids = {
         "rsi": {"period": [7, 14, 21], "oversold": [25, 30], "overbought": [70, 75]},
@@ -201,4 +215,23 @@ def optimize(ctx, ticker, strategy, metric):
     opt = Optimizer()
     df = _fetch_ohlcv(ticker, "1d", "1y")
     best = opt.grid_search(strat_cls, df, _grids.get(strategy, {}), metric=metric)
-    output_json({"ticker": ticker, "strategy": strategy, "metric": metric, "best_params": best})
+    result = {"ticker": ticker, "strategy": strategy, "metric": metric, "best_params": best}
+
+    if sector:
+        from trader.strategies.factory import _SECTOR_PARAMS_FILE, _load_sector_params
+        import trader.strategies.factory as _factory_mod
+        sp_path = _SECTOR_PARAMS_FILE
+        if sp_path.exists():
+            raw = json.loads(sp_path.read_text())
+        else:
+            raw = {}
+        if sector not in raw:
+            raw[sector] = {}
+        raw[sector][strategy] = best
+        sp_path.write_text(json.dumps(raw, indent=2) + "\n")
+        # Invalidate cache so next call picks up new params
+        _factory_mod._sector_cache = None
+        result["sector"] = sector
+        result["sector_params_updated"] = True
+
+    output_json(result)

--- a/trader/cli/watchlist.py
+++ b/trader/cli/watchlist.py
@@ -6,21 +6,44 @@ from trader.adapters.factory import get_adapter
 from trader.cli.__main__ import output_json
 
 # Storage: outputs/watchlists.json
-# Format: {"default": ["NVDA", "AAPL"], "momentum": ["PLTR", "VRT"]}
+# Format:
+#   {"default": {"tickers": ["NVDA","AAPL"], "sectors": {"NVDA": "Technology"}}}
+# Legacy format (plain list) is auto-migrated on load.
 
 def _wl_path(ctx) -> Path:
     output_dir = Path(ctx.find_root().obj.get("output_dir", "outputs"))
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir / "watchlists.json"
 
-def _load(ctx) -> dict[str, list[str]]:
+def _load(ctx) -> dict:
     p = _wl_path(ctx)
     if p.exists():
-        return json.loads(p.read_text())
+        raw = json.loads(p.read_text())
+        # Auto-migrate legacy format: {"name": ["AAPL"]} → {"name": {"tickers": [...], "sectors": {}}}
+        migrated = False
+        for k, v in raw.items():
+            if isinstance(v, list):
+                raw[k] = {"tickers": v, "sectors": {}}
+                migrated = True
+        if migrated:
+            p.write_text(json.dumps(raw, indent=2))
+        return raw
     return {}
 
-def _save(ctx, data: dict[str, list[str]]) -> None:
+def _save(ctx, data: dict) -> None:
     _wl_path(ctx).write_text(json.dumps(data, indent=2))
+
+def _get_tickers(data: dict, list_name: str) -> list[str]:
+    entry = data.get(list_name, {})
+    if isinstance(entry, list):
+        return entry
+    return entry.get("tickers", [])
+
+def _get_sectors(data: dict, list_name: str) -> dict[str, str]:
+    entry = data.get(list_name, {})
+    if isinstance(entry, dict):
+        return entry.get("sectors", {})
+    return {}
 
 
 @click.group()
@@ -33,7 +56,7 @@ def watchlist():
       trader watchlist add NVDA MSFT PLTR
       trader watchlist add VRT AGX --list 52wk-highs
       trader watchlist show
-      trader watchlist show 52wk-highs
+      trader watchlist show 52wk-highs --strategy rsi
       trader watchlist from-scan HIGH_VS_52W_HL --ema200-above --list 52wk-highs
 
     Stored in: outputs/watchlists.json
@@ -55,15 +78,19 @@ def add(ctx, tickers, list_name):
       trader watchlist add VRT AGX UTHR --list 52wk-highs
     """
     data = _load(ctx)
-    existing = set(data.get(list_name, []))
+    entry = data.get(list_name, {"tickers": [], "sectors": {}})
+    if isinstance(entry, list):
+        entry = {"tickers": entry, "sectors": {}}
+    existing = set(entry["tickers"])
     added = [t.upper() for t in tickers if t.upper() not in existing]
-    data[list_name] = sorted(existing | set(t.upper() for t in tickers))
+    entry["tickers"] = sorted(existing | set(t.upper() for t in tickers))
+    data[list_name] = entry
     _save(ctx, data)
     output_json({
         "list": list_name,
         "added": added,
-        "tickers": data[list_name],
-        "total": len(data[list_name]),
+        "tickers": entry["tickers"],
+        "total": len(entry["tickers"]),
     })
 
 
@@ -79,18 +106,25 @@ def remove(ctx, tickers, list_name):
     Example: trader watchlist remove NVDA MSFT --list 52wk-highs
     """
     data = _load(ctx)
+    entry = data.get(list_name, {"tickers": [], "sectors": {}})
+    if isinstance(entry, list):
+        entry = {"tickers": entry, "sectors": {}}
     upper = {t.upper() for t in tickers}
-    current = data.get(list_name, [])
-    removed = [t for t in current if t in upper]
-    data[list_name] = [t for t in current if t not in upper]
-    if not data[list_name]:
+    removed = [t for t in entry["tickers"] if t in upper]
+    entry["tickers"] = [t for t in entry["tickers"] if t not in upper]
+    # Clean sector entries
+    for t in removed:
+        entry.get("sectors", {}).pop(t, None)
+    if not entry["tickers"]:
         del data[list_name]
+    else:
+        data[list_name] = entry
     _save(ctx, data)
     output_json({
         "list": list_name,
         "removed": removed,
-        "tickers": data.get(list_name, []),
-        "total": len(data.get(list_name, [])),
+        "tickers": entry.get("tickers", []),
+        "total": len(entry.get("tickers", [])),
     })
 
 
@@ -107,31 +141,37 @@ def list_watchlists(ctx):
         output_json([])
         return
     output_json([
-        {"list": name, "tickers": tickers, "count": len(tickers)}
-        for name, tickers in sorted(data.items())
+        {"list": name, "tickers": _get_tickers(data, name), "count": len(_get_tickers(data, name))}
+        for name in sorted(data.keys())
     ])
 
 
 @watchlist.command("show")
 @click.argument("list_name", default="default")
 @click.option("--signals", is_flag=True, default=False,
-              help="Include RSI strategy signals alongside quotes.")
+              help="Include sentiment scores alongside quotes (legacy).")
+@click.option("--strategy", default=None,
+              help="Run strategy signals on each ticker (e.g. rsi, macd, ma_cross).")
+@click.option("--interval", default="1d", help="Bar interval for strategy signals.")
+@click.option("--lookback", default="90d", help="History window for strategy signals.")
 @click.pass_context
-def show(ctx, list_name, signals):
+def show(ctx, list_name, signals, strategy, interval, lookback):
     """
     Get live quotes for all tickers in a watchlist.
 
-    Pass --signals to also run RSI signals on each ticker.
+    Pass --strategy to run buy/sell/hold strategy signals on each ticker.
+    Uses sector-optimized parameters when sector data is available.
 
     \b
     Examples:
       trader watchlist show
-      trader watchlist show momentum
+      trader watchlist show momentum --strategy rsi
+      trader watchlist show 52wk-highs --strategy macd --lookback 180d
       trader watchlist show 52wk-highs --signals
-      trader --save watchlist show
     """
     data = _load(ctx)
-    tickers = data.get(list_name, [])
+    tickers = _get_tickers(data, list_name)
+    sector_map = _get_sectors(data, list_name)
     if not tickers:
         output_json({"error": f"Watchlist '{list_name}' is empty or does not exist."})
         sys.exit(1)
@@ -144,8 +184,48 @@ def show(ctx, list_name, signals):
             quotes = await adapter.get_quotes(tickers)
             result = [q.model_dump() for q in quotes]
 
-            if signals:
+            # Attach stored sector info to each quote
+            for r in result:
+                r["sector"] = sector_map.get(r["ticker"], "")
+
+            if strategy:
+                import yfinance as yf
                 from trader.strategies.factory import get_strategy
+                from trader.strategies.risk_filter import RiskFilter
+                from trader.strategies.stop_loss import atr as compute_atr, stop_level as compute_stop
+                from trader.cli.strategies import _fetch_ohlcv
+
+                rf = RiskFilter()
+                for r in result:
+                    ticker = r["ticker"]
+                    try:
+                        df = _fetch_ohlcv(ticker, interval, lookback)
+                        sector = r.get("sector", "")
+                        strat = get_strategy(strategy, sector=sector)
+                        sig_series = strat.signals(df)
+                        raw_signal = int(sig_series.iloc[-1])
+                        try:
+                            current_atr = round(float(compute_atr(df).iloc[-1]), 4)
+                            entry = float(df["close"].iloc[-1])
+                            sl = round(compute_stop(df, entry_price=entry), 4)
+                        except Exception:
+                            current_atr = None
+                            sl = None
+                        filtered = rf.filter(signal=raw_signal, quote=None,
+                                             position=None, sentiment=None)
+                        r["signal"] = filtered["signal"]
+                        r["signal_label"] = {1: "buy", -1: "sell", 0: "hold"}[filtered["signal"]]
+                        r["strategy"] = strategy
+                        r["strategy_params"] = strat.params
+                        r["filtered"] = filtered["filtered"]
+                        r["filter_reason"] = filtered["filter_reason"]
+                        r["atr"] = current_atr
+                        r["stop_level"] = sl
+                    except Exception as e:
+                        r["signal"] = None
+                        r["signal_error"] = str(e)
+
+            if signals:
                 from trader.news.benzinga import BenzingaClient
                 from trader.news.sentiment import SentimentScorer
 
@@ -189,7 +269,7 @@ def clear(ctx, list_name):
     """
     data = _load(ctx)
     if list_name in data:
-        count = len(data[list_name])
+        count = len(_get_tickers(data, list_name))
         del data[list_name]
         _save(ctx, data)
         output_json({"cleared": list_name, "removed_count": count})
@@ -222,6 +302,8 @@ def from_scan(ctx, scan_type, list_name, replace, market, limit,
     """
     Populate a watchlist from a live IBKR scan.
 
+    Stores sector metadata for each ticker to enable sector-optimized strategy signals.
+
     \b
     Examples:
       trader watchlist from-scan HIGH_VS_52W_HL --ema200-above --list 52wk-highs
@@ -253,28 +335,40 @@ def from_scan(ctx, scan_type, list_name, replace, market, limit,
         await adapter.connect()
         try:
             results = await adapter.scan(scan_type, market, filters or None, limit)
-            return [r.symbol for r in results]
+            return results
         finally:
             await adapter.disconnect()
 
     try:
-        new_tickers = asyncio.run(run())
+        results = asyncio.run(run())
     except Exception as e:
         click.echo(json.dumps({"error": str(e), "code": type(e).__name__}))
         sys.exit(1)
 
+    new_tickers = [r.symbol for r in results]
+    new_sectors = {r.symbol: r.sector for r in results if r.sector}
+
     data = _load(ctx)
     if replace:
-        data[list_name] = sorted(set(new_tickers))
+        data[list_name] = {
+            "tickers": sorted(set(new_tickers)),
+            "sectors": new_sectors,
+        }
     else:
-        existing = set(data.get(list_name, []))
-        data[list_name] = sorted(existing | set(new_tickers))
+        entry = data.get(list_name, {"tickers": [], "sectors": {}})
+        if isinstance(entry, list):
+            entry = {"tickers": entry, "sectors": {}}
+        existing = set(entry["tickers"])
+        entry["tickers"] = sorted(existing | set(new_tickers))
+        entry["sectors"] = {**entry.get("sectors", {}), **new_sectors}
+        data[list_name] = entry
     _save(ctx, data)
 
     output_json({
         "list": list_name,
         "scan_type": scan_type,
         "added": new_tickers,
-        "tickers": data[list_name],
-        "total": len(data[list_name]),
+        "sectors": new_sectors,
+        "tickers": _get_tickers(data, list_name),
+        "total": len(_get_tickers(data, list_name)),
     })

--- a/trader/models/quote.py
+++ b/trader/models/quote.py
@@ -9,6 +9,8 @@ class Quote(BaseModel):
     last: float | None = None
     volume: int | None = None
     contract_type: str = "stock"
+    sector: str = ""
+    industry: str = ""
 
 
 class OptionContract(BaseModel):

--- a/trader/models/scan.py
+++ b/trader/models/scan.py
@@ -8,3 +8,5 @@ class ScanResult(BaseModel):
     listing_exchange: str = ""
     sec_type: str = ""
     column_value: str = ""   # the scan metric value (e.g. "12.5%" for gainers)
+    sector: str = ""         # GICS sector e.g. "Technology", "Energy"
+    industry: str = ""       # GICS industry e.g. "Semiconductors"

--- a/trader/strategies/factory.py
+++ b/trader/strategies/factory.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+import json
+from pathlib import Path
 from trader.strategies.rsi import RSIStrategy
 from trader.strategies.macd import MACDStrategy
 from trader.strategies.ma_cross import MACrossStrategy
@@ -13,11 +16,48 @@ _REGISTRY = {
     "momentum": MomentumStrategy,
 }
 
-def get_strategy(name: str, params: dict | None = None) -> BaseStrategy:
+_SECTOR_PARAMS_FILE = Path(__file__).parent / "sector_params.json"
+_sector_cache: dict | None = None
+
+
+def _load_sector_params() -> dict:
+    global _sector_cache
+    if _sector_cache is None:
+        if _SECTOR_PARAMS_FILE.exists():
+            raw = json.loads(_SECTOR_PARAMS_FILE.read_text())
+            # Normalize keys to lowercase for case-insensitive lookup
+            _sector_cache = {k.lower(): v for k, v in raw.items() if isinstance(v, dict)}
+        else:
+            _sector_cache = {}
+    return _sector_cache
+
+
+def get_sector_params(sector: str, strategy_name: str) -> dict | None:
+    """Return param overrides for a sector+strategy combo, or None if not configured."""
+    sp = _load_sector_params()
+    sector_entry = sp.get(sector.lower())
+    if not sector_entry:
+        return None
+    return sector_entry.get(strategy_name.lower())
+
+
+def get_strategy(name: str, params: dict | None = None, sector: str | None = None) -> BaseStrategy:
+    """Create a strategy instance.
+
+    If *sector* is provided and no explicit *params* override, sector-specific
+    defaults are loaded from sector_params.json.  Explicit *params* always win.
+    """
     cls = _REGISTRY.get(name.lower())
     if not cls:
         raise ValueError(f"Unknown strategy '{name}'. Available: {list(_REGISTRY)}")
-    return cls(params)
+    if params:
+        return cls(params)
+    if sector:
+        sector_overrides = get_sector_params(sector, name)
+        if sector_overrides:
+            return cls(sector_overrides)
+    return cls()
+
 
 def list_strategies() -> list[str]:
     return list(_REGISTRY)

--- a/trader/strategies/sector_params.json
+++ b/trader/strategies/sector_params.json
@@ -1,0 +1,80 @@
+{
+  "_comment": "Per-sector strategy parameter overrides. Keys are GICS sector names (case-insensitive matching). Values are strategy-name → param overrides. Falls back to strategy defaults if sector/strategy not listed.",
+  "Technology": {
+    "rsi": {"period": 14, "oversold": 25, "overbought": 75},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 10, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.025},
+    "momentum": {"window": 20, "threshold": 0.04}
+  },
+  "Utilities": {
+    "rsi": {"period": 14, "oversold": 35, "overbought": 65},
+    "macd": {"fast": 8, "slow": 21, "signal": 7},
+    "ma_cross": {"fast_window": 10, "slow_window": 40},
+    "bnf": {"lookback": 15, "breakout_pct": 0.015},
+    "momentum": {"window": 15, "threshold": 0.02}
+  },
+  "Consumer Staples": {
+    "rsi": {"period": 14, "oversold": 35, "overbought": 65},
+    "macd": {"fast": 8, "slow": 21, "signal": 7},
+    "ma_cross": {"fast_window": 10, "slow_window": 40},
+    "bnf": {"lookback": 15, "breakout_pct": 0.015},
+    "momentum": {"window": 15, "threshold": 0.02}
+  },
+  "Energy": {
+    "rsi": {"period": 21, "oversold": 30, "overbought": 70},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 20, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.03},
+    "momentum": {"window": 30, "threshold": 0.05}
+  },
+  "Health Care": {
+    "rsi": {"period": 14, "oversold": 28, "overbought": 72},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 15, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.025},
+    "momentum": {"window": 20, "threshold": 0.04}
+  },
+  "Financials": {
+    "rsi": {"period": 14, "oversold": 30, "overbought": 70},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 20, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.02},
+    "momentum": {"window": 20, "threshold": 0.03}
+  },
+  "Industrials": {
+    "rsi": {"period": 14, "oversold": 30, "overbought": 70},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 20, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.02},
+    "momentum": {"window": 20, "threshold": 0.03}
+  },
+  "Materials": {
+    "rsi": {"period": 21, "oversold": 30, "overbought": 70},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 20, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.025},
+    "momentum": {"window": 25, "threshold": 0.04}
+  },
+  "Real Estate": {
+    "rsi": {"period": 14, "oversold": 32, "overbought": 68},
+    "macd": {"fast": 8, "slow": 21, "signal": 7},
+    "ma_cross": {"fast_window": 15, "slow_window": 40},
+    "bnf": {"lookback": 15, "breakout_pct": 0.02},
+    "momentum": {"window": 20, "threshold": 0.03}
+  },
+  "Communication Services": {
+    "rsi": {"period": 14, "oversold": 28, "overbought": 72},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 15, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.025},
+    "momentum": {"window": 20, "threshold": 0.04}
+  },
+  "Consumer Discretionary": {
+    "rsi": {"period": 14, "oversold": 28, "overbought": 72},
+    "macd": {"fast": 12, "slow": 26, "signal": 9},
+    "ma_cross": {"fast_window": 15, "slow_window": 50},
+    "bnf": {"lookback": 20, "breakout_pct": 0.025},
+    "momentum": {"window": 20, "threshold": 0.04}
+  }
+}


### PR DESCRIPTION
Three interconnected features:

1. Sector metadata pipeline:
   - Add sector/industry fields to ScanResult and Quote models
   - Add get_contract_details() to IBKR adapter for sector lookup
   - Scan results are now enriched with sector/industry from IBKR contract info
   - Watchlist from-scan stores sector metadata alongside tickers

2. Sector parameter profiles:
   - New sector_params.json mapping 11 GICS sectors to strategy param overrides
   - get_strategy() accepts optional sector kwarg for sector-aware defaults
   - Explicit params always override sector defaults
   - strategies optimize --sector writes best params back to sector_params.json

3. Scan-to-signals pipeline:
   - scan run --signals --strategy rsi runs strategy signals on scan results
   - watchlist show --strategy rsi runs real buy/sell/hold signals (not just sentiment)
   - Both use sector-optimized params when sector data is available
   - strategies signals --sector Energy applies sector params directly

https://claude.ai/code/session_01HxZwckZCXHCTEdAgh1Ftot